### PR TITLE
Small typographic errors in bibliography

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -61,7 +61,7 @@
 
 @article{Borrow2020,
   author   = {{Borrow}, Josh and {Borrisov}, Alexei},
-  title    = {{swiftsimio: A Python library for reading SWIFT data}},
+  title    = {{swiftsimio: A {P}ython library for reading {SWIFT} data}},
   journal  = {The Journal of Open Source Software},
   keywords = {Python, cosmology, i/o, simulations, astronomy},
   year     = 2020,
@@ -149,14 +149,14 @@
 
 @misc{gpy2014,
   author =   {{GPy}},
-  title =    {{GPy}: A Gaussian process framework in python},
+  title =    {{GPy}: {A} {G}aussian process framework in {P}ython},
   howpublished = {\url{http://github.com/SheffieldML/GPy}},
   year = {since 2012}
 }
 
 @misc{pyDOE2012,
   author = {Michael Baudin and Maria Christopoulou and Yann Collette and Jean-Marc Martinez},
-  title = {pyDOE: The experimental design package for python},
+  title = {pyDOE: The experimental design package for {P}ython},
   year = {2012},
   publisher = {GitHub},
   journal = {GitHub repository},


### PR DESCRIPTION
I found a few more tiny typographic errors in the bibliography during the final processing for https://github.com/openjournals/joss-reviews/issues/4240 Sorry I didn't catch them before!